### PR TITLE
Fix dependency declarations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,6 @@ plugins {
     id 'application'
 }
 
-group 'dex.mcgitmaker'
-version '0.1.1-SNAPSHOT'
-
 repositories {
     maven {
         name = 'Fabric'
@@ -27,32 +24,32 @@ application {
 }
 
 dependencies {
-    implementation 'org.codehaus.groovy:groovy-all:3.0.11'
+    implementation "org.codehaus.groovy:groovy-all:${groovy_version}"
 
     // Loader and its deps
-    implementation "net.fabricmc:fabric-loader:0.+"
+    implementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     implementation "org.ow2.asm:asm:${project.asm_version}"
     implementation "org.ow2.asm:asm-analysis:${project.asm_version}"
     implementation "org.ow2.asm:asm-commons:${project.asm_version}"
     implementation "org.ow2.asm:asm-tree:${project.asm_version}"
     implementation "org.ow2.asm:asm-util:${project.asm_version}"
 
-    implementation('net.fabricmc:stitch:0.+') {
+    implementation("net.fabricmc:stitch:${stitch_version}") {
         exclude module: 'enigma'
     }
 
     // tinyfile management
-    implementation('net.fabricmc:tiny-remapper:0.+')
-    implementation 'net.fabricmc:access-widener:2.+'
-    implementation 'net.fabricmc:mapping-io:0.+'
+    implementation("net.fabricmc:tiny-remapper:${tiny_remapper_version}")
+    implementation "net.fabricmc:access-widener:${access_widener_version}"
+    implementation "net.fabricmc:mapping-io:${mappingio_version}"
 
-    implementation('net.fabricmc:lorenz-tiny:4.+') {
+    implementation("net.fabricmc:lorenz-tiny:${lorenz_tiny_version}") {
         transitive = false
     }
 
     // https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit
-    implementation 'org.eclipse.jgit:org.eclipse.jgit:6.2.0.202206071550-r'
+    implementation "org.eclipse.jgit:org.eclipse.jgit:${jgit_version}"
 
     // Decompiler, could be replaced with another fernflower fork
-    implementation 'org.quiltmc:quiltflower:1.+'
+    implementation "org.quiltmc:quiltflower:${quiltflower_version}"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,18 @@
+# Gradle Properties
+org.gradle.jvmargs = -Xmx3G
+
+# GitCraft Properties
+group = dex.mcgitmaker
+version = 0.1.1-SNAPSHOT
+
+# GitCraft Dependencies
+groovy_version = 3.0.+
+fabric_loader_version = 0.14.+
 asm_version = 9.3
+stitch_version = 0.6.+
+tiny_remapper_version = 0.8.+
+access_widener_version = 2.1.+
+mappingio_version = 0.3.+
+lorenz_tiny_version = 4.0.+
+jgit_version = 6.2.+
+quiltflower_version = 1.8.+


### PR DESCRIPTION
Depending on `0.+` versions is very risky, because software with a major version number component of 0 is allowed to break API compatibility with minor version updates. Also, even though SemVer should prohibit this, some libraries break compatibility between minor versions (like Quiltflower 1.8 -> 1.9 in this case), so having stricter dependency declarations in general is advisable.
With this PR, GitCraft doesn't crash anymore when trying to decompile MC source code.